### PR TITLE
Add the package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "sourcebots-website",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
This is generated by `npm install`, but (I think) is expected to be committed. Alternatively we should `.gitignore` this file.