### PR TITLE
Use relurl when building calendar events

### DIFF
--- a/layouts/partials/calendar_event.json
+++ b/layouts/partials/calendar_event.json
@@ -2,6 +2,6 @@
   "title": "{{ .Title }}",
   "start": "{{ .Date.Format "2006-01-02T15:04:05" }}",
   "allDay": true,
-  "url": "{{ .Permalink }}",
+  "url": "{{ .RelPermalink }}",
   "color": "{{ .Site.Params.themeColour }}"
 }


### PR DESCRIPTION
As noticed in the preview of https://github.com/sourcebots/website/pull/2, the events on the calendar link to the main site rather than the preview. 