### PR TITLE
Drop full stop at end of the tagline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ theme: mainroad
 
 params:
     themeColour: "#4B35B3"
-    subtitle: Exciting robotics challenges for teams of young people.
+    subtitle: Exciting robotics challenges for teams of young people
     description: SourceBots Robotics — exciting robotics challenges for teams of young people
     readmore: true
     opengraph: true


### PR DESCRIPTION
While it's more correct, it looks rather odd when the tagline is styled to being in all-caps.