### PR TITLE
Add an explicit introduction to the Kickstart event

### DIFF
--- a/content/events/2018/kickstart.md
+++ b/content/events/2018/kickstart.md
@@ -3,6 +3,12 @@ title: Kickstart 2018
 date: 2017-12-16
 ---
 
+Kickstart is the first event of the year and introduces the competition. It
+provides the first opportunity for the teams meet each other and is also when we
+hand out the kits.
+
+<!--more-->
+
 ## Location
 
 Kickstart is being held on the University of Southampton's Highfield Campus:


### PR DESCRIPTION
This improves the clarity of the event page and means that we have a useful summary to show on the main events page. By adding in the `<!--more-->` tag, we tell hugo to explicitly stop the summary at that point.