### PR TITLE
Add link to ical events file

### DIFF
--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -12,11 +12,17 @@
   {{ partial "calendar.html" . }}
 
   <div class="page-content">
-  {{ range .Paginator.Pages.ByDate.Reverse }}
-    {{ .Render "summary" }}
-  {{ end }}
+    {{ $ics := .AlternativeOutputFormats.Get "ics" }}
 
-  {{ partial "pagination.html" . }}
+    Subscribe to the calendar: <a href="{{ $ics.RelPermalink }}">{{ $ics.Permalink }}</a>.
+  </div>
+
+  <div class="page-content">
+    {{ range .Paginator.Pages.ByDate.Reverse }}
+      {{ .Render "summary" }}
+    {{ end }}
+
+    {{ partial "pagination.html" . }}
   </div>
 </main>
 


### PR DESCRIPTION
Publish a link to a calendar teams can subscribe to to see events.

Future nice feature would be to specifically add reminders, but that can come later, if we decide it's a good idea. 