### PR TITLE
Use correct spelling for Smallpeice in .spelling and about.md

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,5 +1,5 @@
 kickstart
-Smallpiece
+Smallpeice
 SourceBots
 00am
 00pm

--- a/content/about.md
+++ b/content/about.md
@@ -22,7 +22,7 @@ University, including teachers and professional engineers.
 
 ## Robotics Summer Schools
 
-Each year, SourceBots works with the Smallpiece Trust to hosted an annual
+Each year, SourceBots works with the Smallpeice Trust to hosted an annual
 robotics competition for Year 12 students (age 16–17) at the University of
 Southampton.
 


### PR DESCRIPTION
I'm not sure if this was intentional (see #23), but this PR should change all instances of "Smallpiece" in the visible website to "Smallpeice".

There are 2 other instances across sourcebots/minutes (2017-10-23) and sourcebots/programming-tutorial, but these don't seem to be publicly facing or recently updated, so I don't think it's worth changing them.