### PR TITLE
Restore RSS support for sections

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,6 +29,7 @@ outputs:
     - "rss"
   section:
     - "html"
+    - "rss"
     - "ics"
 
 menu:


### PR DESCRIPTION
https://trello.com/c/AANOY853/18-rss-atom-json-feed

Was disabled inadvertently when adding ical support, but there's no reason not to restore it.